### PR TITLE
fix: Set package type to module

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "url": "https://github.com/juanelas"
   },
   "repository": "github:juanelas/bigint-conversion",
+  "type": "module",
   "types": "./types/index.d.ts",
   "main": "./dist/cjs/index.node.cjs",
   "browser": "./dist/esm/index.browser.js",


### PR DESCRIPTION
Fixes #10 

Alternatively, you could switch all `.js` files to `.mjs`, and `.cjs` to `.js`, but this was quicker. There are differences between these two approaches, especially when it comes to bundlers, so up to you to decide.